### PR TITLE
Do not append a newline char to @line ivar

### DIFF
--- a/lib/coolline/coolline.rb
+++ b/lib/coolline/coolline.rb
@@ -252,7 +252,7 @@ class Coolline
 
     @history.save_line
 
-    @line + "\n"
+    @line
   end
 
   # Reads a line with no prompt


### PR DESCRIPTION
This commit indirectly fixes issue pry/pry#688 (Coolline repeats the last two
characters of closing blocks) from the bug tracker of `pry`:
https://github.com/pry/pry/issues/688

To be honest, I found out that by accident. I don't fully realize why
this commit fixes the bug, but I think I found a mare's nest.
