### PR TITLE
Remove call to IO#lines

### DIFF
--- a/lib/coolline/history.rb
+++ b/lib/coolline/history.rb
@@ -78,7 +78,7 @@ class Coolline
       @io.rewind
 
       if line_count < @max_size
-        @lines.concat @io.lines.map(&:chomp)
+        @lines.concat @io.map(&:chomp)
       else
         @io.each do |line| # surely inefficient
           @lines << line.chomp


### PR DESCRIPTION
In Ruby 2.0.0, IO#lines is deprecated. Coolline has therefore started to
throw deprecation warnings. Remove the call to IO#lines to reduce
deprecation noise.

Signed-off-by: David Celis me@davidcel.is
