### PR TITLE
Some fixes for Linux terminals (specifically, libvte based ones)

### DIFF
--- a/.gemspec
+++ b/.gemspec
@@ -25,6 +25,8 @@ eof
   s.files |= Dir["test/**/*.rb"]
   s.files << "repl.rb" << ".gemtest"
 
+  s.extra_rdoc_files = ["README.md"]
+
   s.require_paths = %w[lib]
 
   s.add_development_dependency "riot"

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,18 @@
+$LOAD_PATH.unshift File.expand_path(File.join("lib", File.dirname(__FILE__)))
+require 'coolline/version'
+
 task :test do
   ruby "test/run_all.rb"
+end
+
+task :build do
+  sh "gem build .gemspec"
+end
+
+task :release => :build do
+  sh "gem push coolline-#{Coolline::Version}.gem"
+end
+
+task :install => :build do
+  sh "gem install coolline-#{Coolline::Version}.gem"
 end

--- a/lib/coolline/coolline.rb
+++ b/lib/coolline/coolline.rb
@@ -183,21 +183,20 @@ class Coolline
 
   # Reads a line from the terminal
   # @param [String] prompt Characters to print before each line
-  def readline(prompt = ">> ")
+  def readline(prompt = ">> ", default_line = "")
     @prompt = prompt
 
     @history.delete_empty
 
-    @line        = ""
-    @pos         = 0
+    @line        = default_line
+    @pos         = @line.size
     @accumulator = nil
 
     @history_moved = false
 
     @should_exit = false
 
-    reset_line
-    print @prompt
+    render
 
     @history.index = @history.size - 1
     @history << @line
@@ -405,6 +404,11 @@ class Coolline
 
   def word_boundary?(char)
     char =~ word_boundaries_regexp
+  end
+
+  def replace_line(new_line)
+    @line = new_line
+    @pos = new_line.size
   end
 
   private

--- a/lib/coolline/editor.rb
+++ b/lib/coolline/editor.rb
@@ -110,6 +110,15 @@ class Coolline
       end
     end
 
+    # Removes the next word
+    def kill_forward_word
+      if pos != line.size
+        ending = word_end_after(pos)
+
+        line[pos..ending] = ""
+      end
+    end
+
     # Removes the previous character
     def kill_backward_char
       if pos > 0

--- a/lib/coolline/version.rb
+++ b/lib/coolline/version.rb
@@ -1,3 +1,3 @@
 class Coolline
-  Version = "0.4.0"
+  Version = "0.4.1"
 end


### PR DESCRIPTION
- HOME/END keys fixed
- Alt-D hotkey added (deletes the next word, standard in readline)
- IO#getch replaced with IO#raw to make ALT-keys and arrow-keys work in VTE
  (Any keys which send more than 1 character to the terminal were getting
  the 2nd and/or 3rd characters dropped.
  
  After investigation, I figured out that IO#getch was using system calls
  to initialize/deinitialize raw mode EVERY time you called it. This introduced
  enough delay that it would miss some characters.
  
  KDE's konsole didn't have this problem because it emulates a 9600 baud modem,
  but VTE-based terminals, like gnome-terminal, guake, and xfce4-terminal
  send all the characters immediately.
  
  The solution was to just initialize raw mode once with IO#raw, and only
  deinitialize it after the user was finished with readline.
  
  This should fix pasting problems in VTE as well.)
