### PR TITLE
Made the README nicer, and some other small tweaks

### DIFF
--- a/lib/coolline/coolline.rb
+++ b/lib/coolline/coolline.rb
@@ -188,7 +188,7 @@ class Coolline
 
     @history.delete_empty
 
-    @line        = default_line
+    @line        = default_line.dup
     @pos         = @line.size
     @accumulator = nil
 

--- a/lib/coolline/coolline.rb
+++ b/lib/coolline/coolline.rb
@@ -110,6 +110,10 @@ class Coolline
     Coolline::Settings[:handlers].unshift Coolline::Handler.new(key, &action)
   end
 
+  def bind(key, &action)
+    handlers.unshift Coolline::Handler.new(key, &action)
+  end
+
   # Creates a new cool line.
   #
   # @yieldparam [Coolline] self
@@ -180,6 +184,11 @@ class Coolline
 
   # @return [Menu]
   attr_accessor :menu
+
+  # Perform a quick, one-off readline (equivalent to `Coolline.new.readline(...)`)
+  def self.readline(*args)
+    new.readline(*args)
+  end
 
   # Reads a line from the terminal
   # @param [String] prompt Characters to print before each line


### PR DESCRIPTION
- Updated the README (syntax highlighting, more examples, more descriptive); see here: https://github.com/epitron/coolline/blob/master/README.md
- Added `Coolline.readline` (for `Readline.readline` compatability)
- Added `Coolline#bind` (for binding keys on the Coolline instance)
- Fixed a bug (when passing `default_line` to `#readline`, `default_line` wasn't dup'ed, which could clobber the caller's string)
