### PR TITLE
Improvement handling of multibyte characters

### DIFF
--- a/lib/coolline/ansi.rb
+++ b/lib/coolline/ansi.rb
@@ -12,7 +12,7 @@ class Coolline
     # @return [Integer] Amount of characters within the string, disregarding
     #   color codes.
     def ansi_length(string)
-      strip_ansi_codes(string).length
+      strip_ansi_codes(string).each_char.map{|c| c.ascii_only? ? 1 : 2}.inject(0,:+)
     end
 
     # @return [String] The initial string without ANSI codes.

--- a/lib/coolline/coolline.rb
+++ b/lib/coolline/coolline.rb
@@ -432,7 +432,7 @@ class Coolline
 
   def line=(new_line)
     @line = new_line.dup
-    @pos  = new_line.size
+    @pos  = new_line.each_char.map{|c| c.ascii_only? ? 1 : 2}.inject(0,:+)
 
     render
   end


### PR DESCRIPTION
When we type multibyte chalacters, as follows:

```
$ ruby repl.rb
>> "abcdef"
=> "abcdef"
>> "あ                                                                                                                                       >> "あい                                                                                                                                     >> "あいう                                                                                                                                   >> "あいうえ                                                                                                                                 >> "あいうえお                                                                                                                               >> "あいうえお"
=> "あいうえお"
>>
```

![screen shot 2014-08-31 at 9 30 43 am](https://cloud.githubusercontent.com/assets/950573/4100619/11962b52-30a6-11e4-8bab-9049561aec3e.png)

This PR makes like this:

```
$ ruby repl.rb
>> "abcdef"
=> "abcdef"
>> "あいうえお"
=> "あいうえお"
>>
```
