### PR TITLE
[FIX] Ctrl+arrow keys navigation fixed

### DIFF
--- a/coolline.gemspec
+++ b/coolline.gemspec
@@ -1,14 +1,12 @@
 #!/usr/bin/env ruby
 # -*- coding: utf-8 -*-
 
-$LOAD_PATH.unshift File.expand_path(File.join("lib", File.dirname(__FILE__)))
-
-require 'coolline/version'
+require File.expand_path('../lib/coolline/version', __FILE__)
 
 Gem::Specification.new do |s|
   s.name = "coolline"
 
-  s.version = Coolline::Version
+  s.version = Coolline::VERSION
 
   s.summary = "Sounds like readline, smells like readline, but isn't readline"
   s.description = <<-eof

--- a/lib/coolline/coolline.rb
+++ b/lib/coolline/coolline.rb
@@ -503,30 +503,17 @@ class Coolline
   end
 
   def read_char
-  begin
-    # save previous state of stty
-    old_state = `stty -g`
-    # disable echoing and enable raw (not having to press enter)
-    system "stty raw -echo"
-    c = STDIN.getc.chr
-    # gather next two characters of special keys
+    c = STDIN.getch
     if(c=="\e")
       extra_thread = Thread.new{
         7.times{c+= STDIN.getc.chr}
       }
       # wait just long enough for special keys to get swallowed
-      extra_thread.join(0.001)
+      extra_thread.join(0.00001)
       # kill thread so not-so-long special keys don't wait on getc
       extra_thread.kill
     end
-  rescue => ex
-    puts "#{ex.class}: #{ex.message}"
-    puts ex.backtrace
-  ensure
-    # restore previous state of stty
-    system "stty #{old_state}"
+    c
   end
-  return c
-end
 
 end

--- a/lib/coolline/coolline.rb
+++ b/lib/coolline/coolline.rb
@@ -51,8 +51,17 @@ class Coolline
      Handler.new(?\C-a..?\C-z) {},
 
      Handler.new(/\A\e(?:\C-h|\x7F)\z/, &:kill_backward_word),
+     Handler.new("\e[1;5D", &:backward_word),
+     Handler.new("\e[1;5C", &:forward_word),
      Handler.new("\eb", &:backward_word),
-     Handler.new("\ef", &:forward_word),
+     Handler.new("\e[c", &:backward_word),
+     Handler.new("\e[5D", &:backward_word),
+     Handler.new("\eOD", &:backward_word),
+     Handler.new("\eOd", &:backward_word),
+     Handler.new("\e[d", &:forward_word),
+     Handler.new("\e[5C", &:forward_word),
+     Handler.new("\eOC", &:forward_word),
+     Handler.new("\eOc", &:forward_word),
      Handler.new("\e[A", &:previous_history_line),
      Handler.new("\e[B", &:next_history_line),
      Handler.new("\e[3~", &:kill_current_char),
@@ -235,9 +244,8 @@ class Coolline
     @history << @line
 
     @input.raw do |raw_stdin|
-      until (char = raw_stdin.getc) == "\r"
+      until (char = read_char) == "\r"
         @menu.erase
-
         handle(char)
         return if @should_exit
 
@@ -493,4 +501,32 @@ class Coolline
       str
     end
   end
+
+  def read_char
+  begin
+    # save previous state of stty
+    old_state = `stty -g`
+    # disable echoing and enable raw (not having to press enter)
+    system "stty raw -echo"
+    c = STDIN.getc.chr
+    # gather next two characters of special keys
+    if(c=="\e")
+      extra_thread = Thread.new{
+        7.times{c+= STDIN.getc.chr}
+      }
+      # wait just long enough for special keys to get swallowed
+      extra_thread.join(0.001)
+      # kill thread so not-so-long special keys don't wait on getc
+      extra_thread.kill
+    end
+  rescue => ex
+    puts "#{ex.class}: #{ex.message}"
+    puts ex.backtrace
+  ensure
+    # restore previous state of stty
+    system "stty #{old_state}"
+  end
+  return c
+end
+
 end

--- a/lib/coolline/coolline.rb
+++ b/lib/coolline/coolline.rb
@@ -509,7 +509,7 @@ class Coolline
         7.times{c+= STDIN.getc.chr}
       }
       # wait just long enough for special keys to get swallowed
-      extra_thread.join(0.00001)
+      extra_thread.join(0.0001)
       # kill thread so not-so-long special keys don't wait on getc
       extra_thread.kill
     end

--- a/lib/coolline/version.rb
+++ b/lib/coolline/version.rb
@@ -1,3 +1,3 @@
 class Coolline
-  Version = "0.5.1"
+  VERSION = "0.5.1"
 end

--- a/lib/coolline/version.rb
+++ b/lib/coolline/version.rb
@@ -1,3 +1,3 @@
 class Coolline
-  VERSION = "0.5.1"
+  VERSION = "0.5.2"
 end

--- a/lib/coolline/version.rb
+++ b/lib/coolline/version.rb
@@ -1,3 +1,3 @@
 class Coolline
-  Version = "0.5.0"
+  Version = "0.5.1"
 end


### PR DESCRIPTION
In pry you get 5D or 5C symbols, when try move over the line by ctrl+arrow keys.

This will fix it
